### PR TITLE
Added in routes for createEdit

### DIFF
--- a/opencourse-app/src/Components/CourseList.js
+++ b/opencourse-app/src/Components/CourseList.js
@@ -33,6 +33,14 @@ function viewClicked(albumNum) {
   });
 }
 
+function editClicked(albumNum) {
+  console.log("Clocked")
+  history.push({
+    pathname: "/createEdit",
+    state: { detail: albumNum },
+  });
+}
+
 const useStyles = makeStyles((theme) => ({
   icon: {
     marginRight: theme.spacing(2),
@@ -114,13 +122,12 @@ export default function CourseList() {
                       size="small"
                       color="primary"
                       onClick={() => {
-                        console.log(card.course_id)
-                        
-                        return viewClicked(card.course_id)}}
-                    >
+                        return viewClicked(card.course_id)}}>
                       View
                     </Button>
-                    <Button size="small" color="primary">
+                    <Button size="small" color="primary"
+                      onClick={() => {        
+                      return editClicked(card.course_id)}}>
                       Edit
                     </Button>
                   </CardActions>


### PR DESCRIPTION
Added in route for createAndEdit to navigate to page for editing a course. Passes in the course ID in the history location and can be retrieved for use similar to how it is done on the individual course page. 
closes #56
close #57 